### PR TITLE
Pad non-idle qubits in control flow blocks

### DIFF
--- a/qiskit_ibm_provider/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -184,7 +184,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
             TranspilerError: When the coupling map is not supported (i.e., if degree > 3)
         """
 
-        super().__init__()
+        super().__init__(schedule_idle_qubits=schedule_idle_qubits)
         self._durations = durations
 
         # Enforce list of DD sequences


### PR DESCRIPTION
### Summary

This PR proposes two changes:
* Reenable padding in qubits within control flow blocks. 
* Omit idle qubits entirely from control flow blocks. 

### Details and comments

The first change is necessary to apply dynamical decoupling within the control flow blocks. 
The second change is useful where a second padding / DD pass is required. This way, we would only keep the active qubits in the control blocks and prevent scheduling the idle ones. 

### Example

```python
creg = ClassicalRegister(1)
qreg = QuantumRegister(3)
circ = QuantumCircuit(qreg,creg)
circ.sx(qreg[0])
circ.x(qreg[1])
circ.sx(qreg[2])
circ.barrier()
circ.measure(0,creg[0])
with circ.if_test((creg[0], 0)):
    circ.x(qreg[1])

pm = PassManager([ALAPScheduleAnalysis(durations), PadDynamicalDecoupling(durations, [XGate(), XGate()])])
```
![control_flow_pad](https://github.com/mtreinish/qiskit-ibm/assets/10402430/1799424e-646f-4935-a133-efb320a6ea7f)


